### PR TITLE
Add generic types and ability to mutate files on update and delete operations

### DIFF
--- a/lib/jsonl.ts
+++ b/lib/jsonl.ts
@@ -6,10 +6,10 @@ export interface JsonObject {
     [key: string]: any;
 }
 
-export type OnBatchCallback = (batch: JsonObject[]) => boolean | Promise<boolean>;
-export type OnLineCallback = (line: JsonObject) => void | boolean | Promise<void | boolean>;
+export type OnBatchCallback<T extends JsonObject = JsonObject> = (batch: T[]) => boolean | Promise<boolean>;
+export type OnLineCallback<T extends JsonObject = JsonObject> = (line: T) => void | boolean | Promise<void | boolean>;
 
-export function createJsonlFile(filePath: string) {
+export function createJsonlFile<T extends JsonObject = JsonObject>(filePath: string) {
     async function ensure(){
         let fileIsEmpty = false;
         if (!(await safePathExists(filePath))) {
@@ -23,14 +23,14 @@ export function createJsonlFile(filePath: string) {
         return linePrefix;
     }
 
-    async function read(onBatch: OnBatchCallback, batchSize: number = 1000) {
+    async function read(onBatch: OnBatchCallback<T>, batchSize: number = 1000) {
         if (!(await safePathExists(filePath))) {
             return; // File doesn't exist, nothing to read
         }
 
         const rl = getRl(filePath);
 
-        let batch: JsonObject[] = [];
+        let batch: T[] = [];
         let canEndGlobal = false;
 
         try {
@@ -63,7 +63,7 @@ export function createJsonlFile(filePath: string) {
         }
     }
 
-    async function readLineByLine(onLine: OnLineCallback) {
+    async function readLineByLine(onLine: OnLineCallback<T>) {
         if (!(await safePathExists(filePath))) {
             return; // File doesn't exist, nothing to read
         }
@@ -101,7 +101,7 @@ export function createJsonlFile(filePath: string) {
             await fs.appendFile(filePath, linePrefix + lines.join("\n"));
         },
         
-        async append(data: JsonObject | JsonObject[]): Promise<void> {
+        async append(data: T | T[]): Promise<void> {
             const lines = Array.isArray(data) ? data : [data];
             const jsonLines = lines.map(obj => JSON.stringify(obj));
             await this.appendText(jsonLines);

--- a/lib/jsonlDir.ts
+++ b/lib/jsonlDir.ts
@@ -1,28 +1,34 @@
 import { type JsonObject, createJsonlFile } from "./jsonl"
+import { temporaryFileTask } from "./temporaryFileTask";
 import path from "node:path";
+import { promises } from "node:fs";
 
 export function jsonlDir(dirPath: string) {
     return {
-        file(entityName: string) {
+        file<T extends JsonObject = JsonObject>(entityName: string) {
             const filePath = path.join(dirPath, entityName + ".jsonl");
-            const jsonlFile = createJsonlFile(filePath);
+            const jsonlFile = createJsonlFile<T>(filePath);
             return {
-                async add(data: JsonObject | JsonObject[]): Promise<void> {
+                async add(data: T | T[], mutateDb = true): Promise<T[]> {
+                    let itemsToAdd: T[] = [];
                     if (Array.isArray(data)) {
                         if (data.length === 0) {
-                            return;
+                            return [];
                         }
-                        return jsonlFile.appendText(data.map((jsonObject) => JSON.stringify(jsonObject)));
+                        itemsToAdd = data;
+                    } else if (isSingleJson(data)) {
+                        itemsToAdd = [data];
+                    } else {
+                        throw new Error("add() only accepts a single json object or an array of json objects");
                     }
-
-                    if (isSingleJson(data)) {
-                        return jsonlFile.appendText([JSON.stringify(data)]);
+                    if (mutateDb) {
+                        // Persistent: append to file
+                        await jsonlFile.appendText(itemsToAdd.map((jsonObject) => JSON.stringify(jsonObject)));
                     }
-
-                    throw new Error("add() only accepts a single json object or an array of json objects");
+                    return itemsToAdd;
                 },
-                async findOne(matchFn: (data: JsonObject) => boolean): Promise<JsonObject | undefined> {
-                    let found: JsonObject | undefined;
+                async findOne(matchFn: (data: T) => boolean): Promise<T | undefined> {
+                    let found: T | undefined;
                     let canEnd = false;
                      await jsonlFile.read((batch) => {
                         for (const jsonObject of batch) {
@@ -37,8 +43,8 @@ export function jsonlDir(dirPath: string) {
 
                     return found;
                 },
-                async find(matchFn: (data: JsonObject) => boolean): Promise<JsonObject[]> {
-                    let found: JsonObject[] = [];
+                async find(matchFn: (data: T) => boolean): Promise<T[]> {
+                    let found: T[] = [];
                     await jsonlFile.read((batch) => {
                         for (const jsonObject of batch) {
                             if (matchFn(jsonObject)) {
@@ -49,29 +55,77 @@ export function jsonlDir(dirPath: string) {
                     });
                     return found;
                 },
-                async update(matchFn: (data: JsonObject) => boolean, updateFn: (data: JsonObject) => JsonObject): Promise<JsonObject[]> {
-                    let updated: JsonObject[] = [];
-                    await jsonlFile.read((batch) => {  
-                        for (const jsonObject of batch) {
-                            if (matchFn(jsonObject)) {
-                                updated.push(updateFn(jsonObject));
+                async update(matchFn: (data: T) => boolean, updateFn: (data: T) => T, mutateDb = false): Promise<T[]> {
+                    let updated: T[] = [];
+                    if (mutateDb) {
+                        // Persistent: update temporary file, then replace original
+                        await temporaryFileTask(async (tempPath) => {
+                            const tempFile = createJsonlFile<T>(tempPath);
+                            await jsonlFile.read(async (batch) => {
+                                const processedBatch = batch.map(jsonObject => {
+                                    if (matchFn(jsonObject)) {
+                                        const updatedObject = updateFn(jsonObject);
+                                        updated.push(updatedObject);
+                                        return updatedObject;
+                                    }
+                                    return jsonObject;
+                                });
+                                await tempFile.append(processedBatch);
+                                return false;
+                            });
+                            // Atomic rename: replace original with temp file
+                            await promises.rename(tempPath, filePath);
+                        }, { extension: '.jsonl' });
+                        return updated;
+                    } else {
+                        // Non-persistent: just collect and return
+                        await jsonlFile.read((batch) => {
+                            for (const jsonObject of batch) {
+                                if (matchFn(jsonObject)) {
+                                    updated.push(updateFn(jsonObject));
+                                }
                             }
-                        }
-                        return false;
-                    });
-                    return updated;
+                            return false;
+                        });
+                        return updated;
+                    }
                 },
-                async delete(matchFn: (data: JsonObject) => boolean): Promise<JsonObject[]> {
-                    let deleted: JsonObject[] = [];
-                    await jsonlFile.read((batch) => {
-                        for (const jsonObject of batch) {
-                            if (!matchFn(jsonObject)) {
-                                deleted.push(jsonObject);
+                async delete(matchFn: (data: T) => boolean, mutateDb = false): Promise<T[]> {
+                    let kept: T[] = [];
+                    if (mutateDb) {
+                        // Persistent: update temporary file, then replace original
+                        await temporaryFileTask(async (tempPath) => {
+                            const tempFile = createJsonlFile<T>(tempPath);
+                            await jsonlFile.read(async (batch) => {
+                                const keptBatch = batch.filter(jsonObject => {
+                                    if (!matchFn(jsonObject)) {
+                                        kept.push(jsonObject);
+                                        return true; // keep this item
+                                    }
+                                    return false; // exclude from kept items
+                                });
+                                
+                                if (keptBatch.length > 0) {
+                                    await tempFile.append(keptBatch);
+                                }
+                                return false;
+                            });
+                            // Atomic rename: replace original with temp file
+                            await promises.rename(tempPath, filePath);
+                        }, { extension: '.jsonl' });
+                        return kept;
+                    } else {
+                        // Non-persistent: just collect and return
+                        await jsonlFile.read((batch) => {
+                            for (const jsonObject of batch) {
+                                if (!matchFn(jsonObject)) {
+                                    kept.push(jsonObject);
+                                }
                             }
-                        }
-                        return false;
-                    });
-                    return deleted;
+                            return false;
+                        });
+                        return kept;
+                    }
                 },
                 async count() {
                     return await jsonlFile.count();

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "require": "./dist/index.cjs",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.cjs"
     }
   },
   "files": [


### PR DESCRIPTION
Hi, great library!

I've used it in a small project a bit, but ended up needing the ability to actually mutate the source files when updating or deleting rows. In this PR I've added a parameter (mutateDb) to the `add`, `update` and `delete` methods with default values that keep the current behaviour (mutating for add, non-mutating for update and delete). To make this an atomic operation, I've used your `temporaryFileTask` to update/delete the values in a temp file and subsequently replace the original file in a single rename operation.

I've also added generic types that can be passed like this: `jsonlDir("path").file<DataType>("name")`. This provides type safety for returned rows – and falls back to the existing `JsonObject` type if no type is provided.

I've also added tests to cover update and delete when passing `mutateDb=true`.